### PR TITLE
fix: remove table style that is overwriting pie-elements css PD-3910

### DIFF
--- a/site/.vuepress/override.styl
+++ b/site/.vuepress/override.styl
@@ -60,26 +60,6 @@ h6 {
   }
 }
 
-table {
-  tr {
-    &:nth-child(2n) {
-      background-color: $containerBgColor !important;
-    }
-
-    td {
-      min-width: 110px;
-
-      &:nth-child(2) {
-        text-align center;
-      }
-
-      &:nth-child(3) {
-        text-align: right;
-      }
-    }
-  }
-}
-
 blockquote {
   background-color: $containerBgColor;
   border-left: 10px solid $mainColor;


### PR DESCRIPTION
I did not find any purpose of this css and removing it did not seem to break anything
https://illuminate.atlassian.net/browse/PD-3910